### PR TITLE
Add extra checks for boost libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,14 +50,11 @@ AX_BOOST_THREAD
 AX_BOOST_FILESYSTEM
 AX_BOOST_PYTHON
 
-AS_IF([test "x$BOOST_PROGRAM_OPTIONS_LIB" == "x"],
-      [AC_MSG_ERROR([Boost::ProgramOptions library not detected, please install libboost-program-options-dev.])],)
-AS_IF([test "x$BOOST_SYSTEM_LIB" == "x"],
-      [AC_MSG_ERROR([Boost::System library not detected, please install libboost-system-dev.])],)
-AS_IF([test "x$BOOST_THREAD_LIB" == "x"],
-      [AC_MSG_ERROR([Boost::Thread library not detected, please install libboost-thread-dev.])],)
-AS_IF([test "x$BOOST_FILESYSTEM_LIB" == "x"],
-      [AC_MSG_ERROR([Boost::Filesystem library not detected, please install libboost-filesystem-dev.])],)
+# most of the boost AX_BOOST_XXX checks will error if the library is not
+# installed, but the python one continues on regardless. this seems like
+# sensible behaviour if the python bindings are optional, but in our case
+# they are not (yet?), so we must error if boost::python could not be
+# found.
 AS_IF([test "x$BOOST_PYTHON_LIB" == "x"],
       [AC_MSG_ERROR([Boost::Python library not detected, please install libboost-python-dev.])],)
 

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,17 @@ AX_BOOST_THREAD
 AX_BOOST_FILESYSTEM
 AX_BOOST_PYTHON
 
+AS_IF([test "x$BOOST_PROGRAM_OPTIONS_LIB" == "x"],
+      [AC_MSG_ERROR([Boost::ProgramOptions library not detected, please install libboost-program-options-dev.])],)
+AS_IF([test "x$BOOST_SYSTEM_LIB" == "x"],
+      [AC_MSG_ERROR([Boost::System library not detected, please install libboost-system-dev.])],)
+AS_IF([test "x$BOOST_THREAD_LIB" == "x"],
+      [AC_MSG_ERROR([Boost::Thread library not detected, please install libboost-thread-dev.])],)
+AS_IF([test "x$BOOST_FILESYSTEM_LIB" == "x"],
+      [AC_MSG_ERROR([Boost::Filesystem library not detected, please install libboost-filesystem-dev.])],)
+AS_IF([test "x$BOOST_PYTHON_LIB" == "x"],
+      [AC_MSG_ERROR([Boost::Python library not detected, please install libboost-python-dev.])],)
+
 # check pkg-config dependencies
 PKG_CHECK_MODULES([DEPS], [libprime_server >= 0.6.1])
 


### PR DESCRIPTION
This makes it so that failure to find them is a fatal error. Otherwise someone might spend hours wondering what this means :smile_cat: 

```
/usr/bin/ld: cannot find -l-L/home/matt/Programming/Mapzen/valhalla/midgard/.libs
```

@kevinkreiser could you review, please?